### PR TITLE
CIV-2275 Fix typo and add pdf types

### DIFF
--- a/e2e/pages/generalApplication/judgesJourneyPages/makeAnOrder.page.js
+++ b/e2e/pages/generalApplication/judgesJourneyPages/makeAnOrder.page.js
@@ -49,7 +49,7 @@ module.exports = {
         expect(orderText).to.contains('Test Order details');
         I.see('For which document?');
         let documentDropdownValues = await I.grabTextFromAll(this.fields.documentDropdown);
-        expect(documentDropdownValues.toString().replace(/(\r\n|\n|\r)/gm, ', ').trim()).to.equals('--Select a value--, Claim Form, Defense Form');
+        expect(documentDropdownValues.toString().replace(/(\r\n|\n|\r)/gm, ', ').trim()).to.equals('--Select a value--, Claim Form, Defence Form');
         I.selectOption(this.fields.documentDropdown, 'Claim Form');
         I.see('Date for Order to end');
         I.fillField(this.fields.judgeApproveEditOptionDateDay, '01');

--- a/ga-ccd-definition/CaseField/CaseFieldGAspec.json
+++ b/ga-ccd-definition/CaseField/CaseFieldGAspec.json
@@ -147,7 +147,7 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "ID": "generalAppWrittenRepUploadLabel",
-    "Label": "## Before uploading your files, make sure: \n* the file size is no larger than 100MB \n* the file format is either JPG, PNG, SVG, DOC or PDF \n* the file name describes the document you are uploading - for example, 'Receipt for repair work'\n",
+    "Label": "## Before uploading your files, make sure: \n* the file size is no larger than 100MB \n* the file format is either JPG, PNG, SVG, DOC, DOCX, DOT, PDF, RTF, XLT or XLSX \n* the file name describes the document you are uploading - for example, 'Receipt for repair work'\n",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },

--- a/ga-ccd-definition/FixedLists/GAJudgeOrderClaimantOrDefenseFixedList.json
+++ b/ga-ccd-definition/FixedLists/GAJudgeOrderClaimantOrDefenseFixedList.json
@@ -7,8 +7,8 @@
   },
   {
     "ID": "GAJudgeOrderClaimantOrDefenseFixedList",
-    "ListElementCode": "DEFENSE_FORM",
-    "ListElement": "Defense Form",
+    "ListElementCode": "DEFENCE_FORM",
+    "ListElement": "Defence Form",
     "DisplayOrder": 2
   }
 ]


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-2275

### Change description ###

For Which Document dropdown - change Defense to Defence.
Add document types to upload files component text. To include doc, docx, dot, pdf, rtf, xlt or xlsx On Applicant Screen and Upload screens

### Related PRs ###

https://github.com/hmcts/civil-ccd-definition/pull/832
https://github.com/hmcts/civil-general-applications/pull/289

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
