### PR TITLE
Feature/civ 3210 offline rpa application json

### DIFF
--- a/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
@@ -786,6 +786,14 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "litigiousPartyID",
+    "UserRoles": [
+      "caseworker-civil-systemupdate"
+    ],
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "claimant1PartyName",
     "UserRoles": [
       "caseworker-civil-systemupdate"

--- a/ga-ccd-definition/CaseField/CaseFieldGAspec.json
+++ b/ga-ccd-definition/CaseField/CaseFieldGAspec.json
@@ -272,6 +272,13 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
+    "ID": "litigiousPartyID",
+    "Label": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
     "ID": "claimant1PartyName",
     "Label": " ",
     "FieldType": "Text",

--- a/ga-ccd-definition/ComplexTypes/GeneralApplicationGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GeneralApplicationGAspec.json
@@ -133,6 +133,13 @@
   },
   {
     "ID": "GeneralApplicationGAspec",
+    "ListElementCode": "litigiousPartyID",
+    "FieldType": "Text",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "GeneralApplicationGAspec",
     "ListElementCode": "claimant1PartyName",
     "FieldType": "Text",
     "ElementLabel": " ",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-3210

### Change description ###
RPA should only be triggered when a Main Case is taken offline (State - Case Proceeds Offline) and Strike Out Defence order is given by the Judge.  A Strike Out Defence order should update the application state to 'Proceeds in Heritage' which in turn should trigger the 2 RPA tasks to update caseman.  Strike Out defence can be identified when it is the Main Case Claimant (Applicant) who created the application to Strike Out.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
