### PR TITLE
CIV-4769: Fixes for master Pipeline

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -8,6 +8,7 @@
 ./bin/utils/ccd-add-role.sh "judge-profile"
 ./bin/utils/ccd-add-role.sh "basic-access"
 ./bin/utils/ccd-add-role.sh "legal-adviser"
+./bin/utils/ccd-add-role.sh "GS_profile"
 
 roles=("solicitor" "systemupdate" "admin" "staff" "judge")
 for role in "${roles[@]}"

--- a/e2e/tests/ui_tests/1v1GeneralApplication_test.js
+++ b/e2e/tests/ui_tests/1v1GeneralApplication_test.js
@@ -54,7 +54,7 @@ Scenario('GA for 1v1 - Make an order journey', async ({I, api}) => {
   I.dontSee('Applications', 'div.mat-tab-label-content');
 }).retry(0);
 
-Scenario.skip('GA for 1v1 - Direction order journey', async ({I, api}) => {
+Scenario('GA for 1v1 - Direction order journey', async ({I, api}) => {
   parentCaseNumber = await api.createUnspecifiedClaim(config.applicantSolicitorUser, mpScenario, claimantType);
   await api.notifyClaim(config.applicantSolicitorUser, mpScenario, parentCaseNumber);
   await api.notifyClaimDetails(config.applicantSolicitorUser, parentCaseNumber);

--- a/e2e/tests/ui_tests/1v1GeneralApplication_test.js
+++ b/e2e/tests/ui_tests/1v1GeneralApplication_test.js
@@ -54,7 +54,7 @@ Scenario('GA for 1v1 - Make an order journey', async ({I, api}) => {
   I.dontSee('Applications', 'div.mat-tab-label-content');
 }).retry(0);
 
-Scenario('GA for 1v1 - Direction order journey', async ({I, api}) => {
+Scenario.skip('GA for 1v1 - Direction order journey', async ({I, api}) => {
   parentCaseNumber = await api.createUnspecifiedClaim(config.applicantSolicitorUser, mpScenario, claimantType);
   await api.notifyClaim(config.applicantSolicitorUser, mpScenario, parentCaseNumber);
   await api.notifyClaimDetails(config.applicantSolicitorUser, parentCaseNumber);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-4769

### Change description ###
The ga-ccd master and pr pipelines are failing at the AKS deployment stage.  The underlying root cause is that some of the services have longer names which causes issue at the helm upgrade stage.  This restriction was introduced as part of the AKS upgrade and so we did not encounter such issue before.  The platops team suggest we rename the release and service names, which involves changes to multiple occurrences in multiple files.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
