### PR TITLE
CIV-4949 Refactor GA Respondent Appln Collection

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,7 +9,7 @@ def product = "civil"
 def component = "ga-ccd"
 def camundaBranch = "master"
 
-def ccddefbranch = "feature/CIV-3427"
+def ccddefbranch = "gaintegration"
 AppPipelineConfig pipelineConf
 
 static Map<String, Object> secret(String secretName, String envVariable) {

--- a/charts/civil-ga-ccd/values.aat.template.yaml
+++ b/charts/civil-ga-ccd/values.aat.template.yaml
@@ -71,7 +71,7 @@ civil-service:
   java:
     applicationPort: 4000
     releaseNameOverride: ${SERVICE_NAME}-civil-service
-    image: 'hmctspublic.azurecr.io/civil/service:latest'
+    image: 'hmctspublic.azurecr.io/civil/service:pr-1482'
     imagePullPolicy: Always
     ingressHost: civil-ga-ccd-civil-service-staging-aat.service.core-compute-aat.internal
     keyVaults:

--- a/charts/civil-ga-ccd/values.preview.template.yaml
+++ b/charts/civil-ga-ccd/values.preview.template.yaml
@@ -70,7 +70,7 @@ civil-service:
   java:
     applicationPort: 4000
     releaseNameOverride: ${SERVICE_NAME}-civil-service
-    image: 'hmctspublic.azurecr.io/civil/service:pr-1417'
+    image: 'hmctspublic.azurecr.io/civil/service:pr-1482'
     imagePullPolicy: Always
     ingressHost: civil-service-${SERVICE_FQDN}
     keyVaults:

--- a/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
@@ -65,28 +65,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "caseworker-civil-solicitor",
-          "caseworker-civil-admin",
-          "caseworker-civil-systemupdate",
-          "judge-profile"
-        ],
-        "CRUD": "CRU"
-      },
-      {
-        "UserRoles": [
-          "civil-administrator-standard",
-          "civil-administrator-basic"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalAppTypeLabel",
     "AccessControl": [
       {

--- a/ga-ccd-definition/AuthorisationCaseField/StaffGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/StaffGAspec.json
@@ -55,12 +55,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "UserRole": "caseworker-civil-staff",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalOrderDocument",
     "CRUD": "R",
     "UserRole": "caseworker-civil-staff"

--- a/ga-ccd-definition/AuthorisationCaseField/caseAccessAssignmentGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/caseAccessAssignmentGAspec.json
@@ -16,11 +16,5 @@
     "CaseFieldID": "gaDetailsRespondentSol",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
   }
 ]

--- a/ga-ccd-definition/AuthorisationComplexType/judgeProfileGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/judgeProfileGAspec.json
@@ -559,34 +559,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalAppSubmittedDateGAspec",
-    "UserRole": "judge-profile",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseLink",
-    "UserRole": "judge-profile",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseState",
-    "UserRole": "judge-profile",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalApplicationType",
-    "UserRole": "judge-profile",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
     "ListElementCode": "generalAppDateDeadline",
     "UserRole": "judge-profile",

--- a/ga-ccd-definition/AuthorisationComplexType/staff.json
+++ b/ga-ccd-definition/AuthorisationComplexType/staff.json
@@ -559,34 +559,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalAppSubmittedDateGAspec",
-    "UserRole": "civil-administrator-standard",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseLink",
-    "UserRole": "civil-administrator-standard",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseState",
-    "UserRole": "civil-administrator-standard",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalApplicationType",
-    "UserRole": "civil-administrator-standard",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
     "ListElementCode": "generalAppDateDeadline",
     "UserRole": "civil-administrator-standard",
@@ -1363,34 +1335,6 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "gaDetailsRespondentSol",
-    "ListElementCode": "generalApplicationType",
-    "UserRole": "civil-administrator-basic",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalAppSubmittedDateGAspec",
-    "UserRole": "civil-administrator-basic",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseLink",
-    "UserRole": "civil-administrator-basic",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseState",
-    "UserRole": "civil-administrator-basic",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
     "ListElementCode": "generalApplicationType",
     "UserRole": "civil-administrator-basic",
     "CRUD": "R"

--- a/ga-ccd-definition/AuthorisationComplexType/systemUpdateGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/systemUpdateGAspec.json
@@ -615,34 +615,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalAppSubmittedDateGAspec",
-    "UserRole": "caseworker-civil-systemupdate",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseLink",
-    "UserRole": "caseworker-civil-systemupdate",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "caseState",
-    "UserRole": "caseworker-civil-systemupdate",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "gaDetailsRespondentSolTwo",
-    "ListElementCode": "generalApplicationType",
-    "UserRole": "caseworker-civil-systemupdate",
-    "CRUD": "CRU"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
     "ListElementCode": "generalAppDateDeadline",
     "UserRole": "caseworker-civil-systemupdate",

--- a/ga-ccd-definition/CaseField/CaseFieldGAspec.json
+++ b/ga-ccd-definition/CaseField/CaseFieldGAspec.json
@@ -357,17 +357,6 @@
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
-    "ID": "gaDetailsRespondentSolTwo",
-    "Label": " ",
-    "ElementLabel": "Application Type",
-    "FieldType": "Collection",
-    "FieldTypeParameter": "GeneralApplicationDetailsGAspec",
-    "SecurityClassification": "Public",
-    "_Definition":  "The details of the child application on the case",
-    "_Category":  "COMMON"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
     "ID": "generalAppRespondent1Representative",
     "Label": "Do you agree that the court should make the order that the applicant has requested?",
     "FieldType": "GARespondentRepresentativeGAspec",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-4949


### Change description ###

Since all the respondents for GA share the same collections of generalapplications details. we can remove the following field. 

private final List<Element<GADetailsRespondentSol>> gaDetailsRespondentSolTwo;

 

Use the field "gaDetailsRespondentSol" to display the general applications details for all the respondents individually.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
