### PR TITLE
Updated permissions to case state additional response time expired to…

### DIFF
--- a/ga-ccd-definition/AuthorisationCaseState/AuthorisationCaseStateGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseState/AuthorisationCaseStateGAspec.json
@@ -187,6 +187,7 @@
       {
         "UserRoles": [
           "civil-administrator-basic",
+          "caseworker-civil-solicitor",
           "caseworker-ras-validation",
           "ga-basic-access"
         ],


### PR DESCRIPTION
Updated permissions to casestate "Additional Response time expired" to allow solicitors to view general applications
**Before creating a pull request make sure that:**

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-5665

### Change description ###

At the moment Solicitors does not have permission to search for cases which are in "Additional Response Time Expired". This PR will allow solicitors to have a read permission of all ga which are in state Additional Response Time Expired

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
