### PR TITLE
CIV-6171 Remove Solicitor permission to Judge Reason fields

### DIFF
--- a/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
@@ -628,7 +628,6 @@
       },
       {
         "UserRoles": [
-          "caseworker-civil-solicitor",
           "judge-profile",
           "legal-adviser"
         ],

--- a/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
@@ -628,6 +628,7 @@
       },
       {
         "UserRoles": [
+          "caseworker-civil-solicitor",
           "judge-profile",
           "legal-adviser"
         ],

--- a/ga-ccd-definition/AuthorisationComplexType/solicitorGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/solicitorGAspec.json
@@ -247,13 +247,6 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
-    "ListElementCode": "generalAppReasonsOfOrder",
-    "UserRole": "caseworker-civil-solicitor",
-    "CRUD": "R"
-  },
-  {
-    "CaseTypeID": "GENERALAPPLICATION",
-    "CaseFieldID": "generalApplications",
     "ListElementCode": "generalAppHearingDetails",
     "UserRole": "caseworker-civil-solicitor",
     "CRUD": "CRU"
@@ -721,7 +714,7 @@
     "CaseFieldID": "judicialDecisionMakeOrder",
     "ListElementCode": "reasonForDecisionText",
     "UserRole": "caseworker-civil-solicitor",
-    "CRUD": "CRU"
+    "CRUD": "C"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",

--- a/ga-ccd-definition/AuthorisationComplexType/solicitorGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/solicitorGAspec.json
@@ -247,6 +247,13 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
+    "ListElementCode": "generalAppReasonsOfOrder",
+    "UserRole": "caseworker-civil-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "generalApplications",
     "ListElementCode": "generalAppHearingDetails",
     "UserRole": "caseworker-civil-solicitor",
     "CRUD": "CRU"


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6171


### Change description ###
Remove Solicitor permission to the following fields as it should be visible to judge, staff, legal advisor and case worker

reasonForDecisionText




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
