### PR TITLE
CIV-6294 Moved FieldShowCondition to CaseEventToComplexTypes 

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -188,4 +188,8 @@
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
   </suppress>
+  <suppress>
+    <notes>Temporariy suppressing it as the latest camunda connector 1.5.6 seem to have the vulnerability.</notes>
+    <cve>CVE-2021-37533</cve>
+  </suppress>
 </suppressions>

--- a/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
+++ b/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
@@ -53,7 +53,7 @@
     "EventElementLabel": " ",
     "FieldDisplayOrder": 5,
     "DisplayContext": "MANDATORY",
-    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDoc=\"Yes\""
+    "FieldShowCondition": "judicialDecisionMakeOrder.makeAnOrder=\"APPROVE_OR_EDIT\" AND judicialDecisionMakeOrder.displayjudgeApproveEditOptionDoc=\"Yes\""
   },
   {
     "ID": "GAJudicialMakeADecisionScreen",
@@ -63,7 +63,7 @@
     "EventElementLabel": " ",
     "FieldDisplayOrder": 6,
     "DisplayContext": "MANDATORY",
-    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDate=\"Yes\""
+    "FieldShowCondition": "judicialDecisionMakeOrder.makeAnOrder=\"APPROVE_OR_EDIT\" AND judicialDecisionMakeOrder.displayjudgeApproveEditOptionDate=\"Yes\""
 
   },
   {

--- a/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
+++ b/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
@@ -52,7 +52,8 @@
     "ListElementCode": "judgeApproveEditOptionDoc",
     "EventElementLabel": " ",
     "FieldDisplayOrder": 5,
-    "DisplayContext": "MANDATORY"
+    "DisplayContext": "MANDATORY",
+    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDoc=\"Yes\""
   },
   {
     "ID": "GAJudicialMakeADecisionScreen",
@@ -61,7 +62,9 @@
     "ListElementCode": "judgeApproveEditOptionDate",
     "EventElementLabel": " ",
     "FieldDisplayOrder": 6,
-    "DisplayContext": "MANDATORY"
+    "DisplayContext": "MANDATORY",
+    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDate=\"Yes\""
+
   },
   {
     "ID": "GAJudicialMakeADecisionScreen",

--- a/ga-ccd-definition/CaseEventToFields/JudicialDecisionGAspec.json
+++ b/ga-ccd-definition/CaseEventToFields/JudicialDecisionGAspec.json
@@ -58,7 +58,7 @@
     "PageFieldDisplayOrder": 4,
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "COMPLEX",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/ga-ccd-definition/ComplexTypes/GAJudicialMakeAnOrderGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GAJudicialMakeAnOrderGAspec.json
@@ -29,16 +29,15 @@
     "ElementLabel": "For which document?",
     "FieldType": "FixedList",
     "FieldTypeParameter": "GAJudgeOrderClaimantOrDefenseFixedList",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDoc=\"Yes\""
+    "SecurityClassification": "Public"
+
   },
   {
     "ID": "GAJudicialMakeAnOrderGAspec",
     "ListElementCode": "judgeApproveEditOptionDate",
     "ElementLabel": "Date for Order to end",
     "FieldType": "Date",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "makeAnOrder=\"APPROVE_OR_EDIT\" AND displayjudgeApproveEditOptionDate=\"Yes\""
+    "SecurityClassification": "Public"
   },
   {
     "ID": "GAJudicialMakeAnOrderGAspec",


### PR DESCRIPTION
CIV-6294 Moved FieldShowCondition to CaseEventToComplexTypes to make the fields visible on check your answers page

**Before creating a pull request make sure that:**

- [ x] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-6294

### Change description ###

Moved FieldShowCondition from complexTypes to CaseEventToComplexTypes to make the caseFields visible in check your answers page 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
