### PR TITLE
CIV-6543 Fix Judicial Written Rep field label

### DIFF
--- a/e2e/pages/generalApplication/judgesJourneyPages/drawGeneralOrder.page.js
+++ b/e2e/pages/generalApplication/judgesJourneyPages/drawGeneralOrder.page.js
@@ -35,7 +35,7 @@ module.exports = {
       await I.see('The respondent may upload any written representations by 4pm on');
       await I.see('The applicant may upload any written representations by 4pm on');
     } else {
-      await I.see('The applicant and respondent must respond with written representations by 4pm on');
+      await I.see('The applicant and respondent may respond with written representations by 4pm on');
     }
     await I.clickContinue();
   },

--- a/e2e/pages/generalApplication/judgesJourneyPages/judgesSummary.page.js
+++ b/e2e/pages/generalApplication/judgesJourneyPages/judgesSummary.page.js
@@ -55,7 +55,7 @@ module.exports = {
       case 'Approve order':
         await I.see('Judge’s recital');
         await verifyJudgeRecitalText(await I.grabTextFrom(locate(this.fields.summaryLabels).first()), notice);
-        await I.see('Date for Order to end');
+        await I.see('Order for Stay to End');
         await I.see('For which document?');
         await I.see('Reasons for decision');
         break;

--- a/e2e/pages/generalApplication/judgesJourneyPages/makeAnOrder.page.js
+++ b/e2e/pages/generalApplication/judgesJourneyPages/makeAnOrder.page.js
@@ -51,7 +51,7 @@ module.exports = {
         let documentDropdownValues = await I.grabTextFromAll(this.fields.documentDropdown);
         expect(documentDropdownValues.toString().replace(/(\r\n|\n|\r)/gm, ', ').trim()).to.equals('--Select a value--, Claim Form, Defence Form');
         I.selectOption(this.fields.documentDropdown, 'Claim Form');
-        I.see('Date for Order to end');
+        I.see('Order for Stay to End');
         I.fillField(this.fields.judgeApproveEditOptionDateDay, '01');
         I.fillField(this.fields.judgeApproveEditOptionDateMonth, '01');
         I.fillField(this.fields.judgeApproveEditOptionDateYear, '2024');

--- a/e2e/pages/generalApplication/judgesJourneyPages/writtenRepresentations.page.js
+++ b/e2e/pages/generalApplication/judgesJourneyPages/writtenRepresentations.page.js
@@ -39,7 +39,7 @@ module.exports = {
         I.fillField(this.fields.applicantSequentialRepYear, '2024');
         break;
       case 'concurrentRep':
-        I.see('Any written representations and any further witness statements may be uploaded by 4pm on');
+        I.see('Any written representations may be uploaded by 4pm on');
         I.fillField(this.fields.concurrentRepDay, '01');
         I.fillField(this.fields.concurrentRepMonth, '01');
         I.fillField(this.fields.concurrentRepYear, '2024');

--- a/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
+++ b/ga-ccd-definition/CaseEventToComplexTypes/JudicialDecisionGAspec.json
@@ -62,7 +62,7 @@
     "ListElementCode": "judgeApproveEditOptionDate",
     "EventElementLabel": " ",
     "FieldDisplayOrder": 6,
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "judicialDecisionMakeOrder.makeAnOrder=\"APPROVE_OR_EDIT\" AND judicialDecisionMakeOrder.displayjudgeApproveEditOptionDate=\"Yes\""
   },
   {

--- a/ga-ccd-definition/ComplexTypes/GAJudicialMakeAnOrderGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GAJudicialMakeAnOrderGAspec.json
@@ -34,7 +34,7 @@
   {
     "ID": "GAJudicialMakeAnOrderGAspec",
     "ListElementCode": "judgeApproveEditOptionDate",
-    "ElementLabel": "Date for Order to end",
+    "ElementLabel": "Order for Stay to End",
     "FieldType": "Date",
     "SecurityClassification": "Public"
   },

--- a/ga-ccd-definition/ComplexTypes/GAJudicialWrittenRepresentationsGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GAJudicialWrittenRepresentationsGAspec.json
@@ -26,7 +26,7 @@
   {
     "ID": "GAJudicialWrittenRepresentationsGAspec",
     "ListElementCode": "writtenConcurrentRepresentationsBy",
-    "ElementLabel": "Any written representations and any further witness statements may be uploaded by 4pm on",
+    "ElementLabel": "Any written representations may be uploaded by 4pm on",
     "FieldType": "Date",
     "SecurityClassification": "Public",
     "FieldShowCondition": "makeAnOrderForWrittenRepresentations = \"CONCURRENT_REPRESENTATIONS\""


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-6543
https://tools.hmcts.net/jira/browse/CIV-6542

### Change description ###

CIV-6543

1. On concurrent representations, Label should be "Any written representations may be uploaded by 4pm on"
2. Update "must" to "may" on the recital/directions screen for concurrent represenations

CIV-6542

Remove Order to end date field for Extend time
Rename Order to end date field for Stay the claim to "Order for Stay to End"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
