### PR TITLE
CIV-8143 Legal Advisor needs to be able to refer to Judge

### DIFF
--- a/ga-ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventGAspec.json
@@ -380,7 +380,9 @@
     "AccessControl": [
       {
         "UserRoles": [
-          "civil-administrator-standard"
+          "civil-administrator-standard",
+          "legal-adviser"
+
         ],
         "CRUD": "CRU"
       },

--- a/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
+++ b/ga-ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldGAspec.json
@@ -2387,7 +2387,8 @@
       {
         "UserRoles": [
           "civil-administrator-standard",
-          "caseworker-civil-systemupdate"
+          "caseworker-civil-systemupdate",
+          "legal-adviser"
         ],
         "CRUD": "CRU"
       },


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-8143

### Change description ###

Legal Advisor needs to be able to refer to Judge

Once Legal Advisors receive a work allocation task to make a decision they are able to run an event on the application to make a decision. They need to be able to run an event which refers the application to a Judge in the scenario where the Legal Advisor cannot make a decision. The current requirement was that the LA would unassign the task for another LA to pick up. This will only be applicable to Pre-SDO cases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
