### PR TITLE
CIV-8134 Update permissions for legal advisor

### DIFF
--- a/ga-ccd-definition/AuthorisationComplexType/legalAdviserGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/legalAdviserGAspec.json
@@ -870,83 +870,83 @@
     "CaseFieldID": "judicialDecisionMakeOrder",
     "ListElementCode": "orderCourtOwnInitiative",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "judicialDecisionMakeOrder",
     "ListElementCode": "orderCourtOwnInitiativeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "judicialDecisionMakeOrder",
     "ListElementCode": "orderWithoutNotice",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "judicialDecisionMakeOrder",
     "ListElementCode": "orderWithoutNoticeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderCourtOwnInitiativeListForHearing",
     "ListElementCode": "orderCourtOwnInitiative",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderCourtOwnInitiativeListForHearing",
     "ListElementCode": "orderCourtOwnInitiativeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderWithoutNoticeListForHearing",
     "ListElementCode": "orderWithoutNotice",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderWithoutNoticeListForHearing",
     "ListElementCode": "orderWithoutNoticeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderCourtOwnInitiativeForWrittenRep",
     "ListElementCode": "orderCourtOwnInitiative",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderCourtOwnInitiativeForWrittenRep",
     "ListElementCode": "orderCourtOwnInitiativeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderWithoutNoticeForWrittenRep",
     "ListElementCode": "orderWithoutNotice",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "orderWithoutNoticeForWrittenRep",
     "ListElementCode": "orderWithoutNoticeDate",
     "UserRole": "legal-adviser",
-    "CRUD": "R"
+    "CRUD": "CRU"
   }
 ]


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-8134

### Change description ###

Consent Orders are initially going to be sent to Caseworkers to review.  There will be instances when caseworkers will not be able to decide on the Consent Order, In this instance they will need to refer the order to a Legal Advisor to make a decision.  They will do this via the UI on CCD.  Once a Consent Order has been referred to a Legal Advisor, the event should trigger a Work Allocation task for a LA to review the application.  The LA will then be able to make a decision using the current screen available to them.  The resulting state from the decision will depend on the choice the LA makes but will follow the current functionality.

 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
