### PR TITLE
CIV-11205 Add new fields in GA to store court address and postcode

### DIFF
--- a/ga-ccd-definition/AuthorisationComplexType/judgeProfileGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/judgeProfileGAspec.json
@@ -910,6 +910,20 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
+    "ListElementCode": "caseManagementLocation.address",
+    "UserRole": "judge-profile",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "generalApplications",
+    "ListElementCode": "caseManagementLocation.postcode",
+    "UserRole": "judge-profile",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "generalApplications",
     "ListElementCode": "isCcmccLocation",
     "UserRole": "judge-profile",
     "CRUD": "R"

--- a/ga-ccd-definition/AuthorisationComplexType/systemUpdateGAspec.json
+++ b/ga-ccd-definition/AuthorisationComplexType/systemUpdateGAspec.json
@@ -560,6 +560,20 @@
   {
     "CaseTypeID": "GENERALAPPLICATION",
     "CaseFieldID": "generalApplications",
+    "ListElementCode": "caseManagementLocation.address",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "generalApplications",
+    "ListElementCode": "caseManagementLocation.postcode",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "CaseFieldID": "generalApplications",
     "ListElementCode": "isCcmccLocation",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "CRU"

--- a/ga-ccd-definition/ComplexTypes/GACaseLocationGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GACaseLocationGAspec.json
@@ -19,5 +19,19 @@
     "ElementLabel": " ",
     "FieldType": "Text",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "GACaseLocationGAspec",
+    "ListElementCode": "address",
+    "ElementLabel": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "GACaseLocationGAspec",
+    "ListElementCode": "postcode",
+    "ElementLabel": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-11205


### Change description ###

Currently in Applications we only store the full address of the courts. We need an additional field for just the court name so that this can appear on the Orders generated on an application.

Applies to ALL Templates

General Order
Dismissal Order
Directions Order
Request More Info Order
Hearing Order
Written Representation Concurrent
Written Representation Sequential
Free Form Order
Assisted Order
Consent Order

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
