### PR TITLE
CIV-12628 Fix Application tab field with notice

### DIFF
--- a/ga-ccd-definition/CaseTypeTab/ApplicationDetailsGAspec.json
+++ b/ga-ccd-definition/CaseTypeTab/ApplicationDetailsGAspec.json
@@ -304,6 +304,7 @@
     "TabLabel": "Application",
     "TabDisplayOrder": 1,
     "CaseFieldID": "generalAppInformOtherParty",
+    "FieldShowCondition": "generalAppRespondentAgreement.hasAgreed = \"No\"",
     "TabFieldDisplayOrder": 13
   },
   {


### PR DESCRIPTION
Req. https://tools.hmcts.net/jira/browse/CIV-3772

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-12628


### Change description ###
Add field show condition for isWithNotice to be displayed if RespondentAgreement is No in Application page tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
