### PR TITLE
DTSCCI-490 remove deprecated property volume lib

### DIFF
--- a/charts/civil-ga-ccd/values.template.yaml
+++ b/charts/civil-ga-ccd/values.template.yaml
@@ -33,7 +33,7 @@ civil-general-applications:
           - name: robotics-notification-recipient
             alias: robotics.notification.recipient
           - name: launch-darkly-sdk-key-non-prod
-            alias: launch-darkly-sdk-key
+            alias: LAUNCH_DARKLY_SDK_KEY
           - name: robotics-notification-multipartyrecipient
             alias: robotics.notification.multipartyrecipient
       civil-gen-apps:


### PR DESCRIPTION

### JIRA link (if applicable) ###
DTSCCI-490


### Change description ###
cahnged alias: LAUNCH_DARKLY_SDK_KEY from launch-darkly-sdk-key


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
