### PR TITLE
CIV-15175 Adding CTSC Auths for Application Document Tab

### DIFF
--- a/ga-ccd-definition/CaseTypeTab/ApplicationDocumentsCtsc-CUI-nonprod.json
+++ b/ga-ccd-definition/CaseTypeTab/ApplicationDocumentsCtsc-CUI-nonprod.json
@@ -1,0 +1,182 @@
+[
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "generalOrderDocument",
+    "TabFieldDisplayOrder": 1,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "dismissalOrderDocument",
+    "TabFieldDisplayOrder": 2,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "directionOrderDocument",
+    "TabFieldDisplayOrder": 3,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "requestForInformationDocument",
+    "TabFieldDisplayOrder": 4,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "hearingOrderDocument",
+    "TabFieldDisplayOrder": 5,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "writtenRepSequentialDocument",
+    "TabFieldDisplayOrder": 6,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "writtenRepConcurrentDocument",
+    "TabFieldDisplayOrder": 7,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaWrittenRepDocList",
+    "TabFieldDisplayOrder": 8
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaDirectionDocList",
+    "TabFieldDisplayOrder": 9
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaAddlnInfoList",
+    "TabFieldDisplayOrder": 10
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "generalAppEvidenceDocument",
+    "TabFieldDisplayOrder": 11
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "generalAppN245FormUpload",
+    "TabFieldDisplayOrder": 12
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "hearingNoticeDocument",
+    "TabFieldDisplayOrder": 13,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "consentOrderDocument",
+    "TabFieldDisplayOrder": 14,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaDraftDocument",
+    "TabFieldDisplayOrder": 15,
+
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaRespondDoc",
+    "TabFieldDisplayOrder": 16,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  },
+  {
+  "CaseTypeID": "GENERALAPPLICATION",
+  "TabID": "ApplicationDocumentsCtsc",
+  "TabLabel": "Application Documents",
+  "TabDisplayOrder": 4,
+  "CaseFieldID": "gaAddlDocClaimant",
+  "TabFieldDisplayOrder": 17,
+  "UserRoles": [
+    "cui-admin-profile"
+  ],
+  "DisplayContextParameter": "#TABLE(documentName, createdDatetime, documentLink, createdBy)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaAddlDocRespondentSol",
+    "TabFieldDisplayOrder": 18,
+    "DisplayContextParameter": "#TABLE(documentName, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaAddlDocRespondentSolTwo",
+    "TabFieldDisplayOrder": 19,
+    "DisplayContextParameter": "#TABLE(documentName, createdDatetime, documentLink)"
+  },
+  {
+    "CaseTypeID": "GENERALAPPLICATION",
+    "TabID": "ApplicationDocumentsCtsc",
+    "TabLabel": "Application Documents",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "gaAddlDocBundle",
+    "TabFieldDisplayOrder": 20,
+    "DisplayContextParameter": "#TABLE(documentType, createdDatetime, documentLink)"
+  }
+]
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-15175


### Change description ###
Adding auths so that CTSC users are able to see the application documents tab when viewing applications 
Changes added to CUI-nonprod file

![image](https://github.com/user-attachments/assets/c624c373-98df-4086-a38f-3f21d5c321a2)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
