### PR TITLE
DTSCCI-0059 Configure to use civil-service app insights from key vault

### DIFF
--- a/charts/civil-ga-ccd/values.aat.template.yaml
+++ b/charts/civil-ga-ccd/values.aat.template.yaml
@@ -21,7 +21,7 @@ civil-general-applications:
             alias: CIVIL_PRD_ADMIN_USERNAME
           - name: prd-admin-user-password
             alias: CIVIL_PRD_ADMIN_PASSWORD
-          - name: AppInsightsInstrumentationKeyGeneralApplications
+          - name: appinsights-instrumentation-key
             alias: azure.application-insights.instrumentation-key
           - name: docmosis-api-key
             alias: docmosis.tornado.key

--- a/charts/civil-ga-ccd/values.preview.template.yaml
+++ b/charts/civil-ga-ccd/values.preview.template.yaml
@@ -21,7 +21,7 @@ civil-general-applications:
             alias: CIVIL_PRD_ADMIN_USERNAME
           - name: prd-admin-user-password
             alias: CIVIL_PRD_ADMIN_PASSWORD
-          - name: AppInsightsInstrumentationKeyGeneralApplications
+          - name: appinsights-instrumentation-key
             alias: azure.application-insights.instrumentation-key
           - name: docmosis-api-key
             alias: docmosis.tornado.key

--- a/charts/civil-ga-ccd/values.template.yaml
+++ b/charts/civil-ga-ccd/values.template.yaml
@@ -20,7 +20,7 @@ civil-general-applications:
             alias: CIVIL_PRD_ADMIN_USERNAME
           - name: prd-admin-user-password
             alias: CIVIL_PRD_ADMIN_PASSWORD
-          - name: AppInsightsInstrumentationKeyGeneralApplications
+          - name: appinsights-instrumentation-key
             alias: azure.application-insights.instrumentation-key
           - name: docmosis-api-key
             alias: docmosis.tornado.key

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,4 +41,4 @@ spring:
 
 azure:
   application-insights:
-    instrumentation-key: ${civil.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
+    instrumentation-key: ${civil.appinsights-instrumentation-key:00000000-0000-0000-0000-000000000000}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-59


### Change description ###
Configure to use civil-service app insights from key vault


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
