### PR TITLE
CIV-16410 - Respondent unable to submit response to an urgent application when it's Without Notice to Notice

### DIFF
--- a/ga-ccd-definition/CaseEvent/User/UserEventsGAspec-CUI-nonprod.json
+++ b/ga-ccd-definition/CaseEvent/User/UserEventsGAspec-CUI-nonprod.json
@@ -157,7 +157,7 @@
     "ID": "RESPOND_TO_APPLICATION_URGENT_LIP",
     "Name": "Respond to application",
     "Description": "Applicant response",
-    "PreConditionState(s)": "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION",
+    "PreConditionState(s)": "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION;AWAITING_RESPONDENT_RESPONSE",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
     "EndButtonLabel": "Submit",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16410


### Change description ###
A pre-condition was added to submit a lip respondent response for an urgent application.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
