### PR TITLE
CIV-16221 - GA LRvLip - "Vulnerability questions" text should match the font style of the other headings in XUI

### DIFF
--- a/ga-ccd-definition/ComplexTypes/GAHearingDetailsGAspec.json
+++ b/ga-ccd-definition/ComplexTypes/GAHearingDetailsGAspec.json
@@ -176,7 +176,7 @@
   {
     "ID": "GAHearingDetailsGAspec",
     "ListElementCode": "vulnerabilityQuestionsLabel",
-    "ElementLabel": "Vulnerability questions",
+    "ElementLabel": "#### Vulnerability questions",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16221


### Change description ###
Added a fix to bold the 'Vulnerability questions' header.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
