### PR TITLE
CIV-16638 Modifed api test for vary judgement journey

### DIFF
--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -787,10 +787,10 @@ module.exports = {
     assert.equal(response.status, 201);
     assert.equal(responseBody.callback_response_status_code, 200);
     assert.include(responseBody.after_submit_callback_response.confirmation_header, '# You have provided the requested information');
-    await waitForGACamundaEventsFinishedBusinessProcess(gaCaseId, 'APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION', user);
+    await waitForGACamundaEventsFinishedBusinessProcess(gaCaseId, 'PROCEEDS_IN_HERITAGE', user);
     const updatedBusinessProcess = await apiRequest.fetchUpdatedGABusinessProcessData(gaCaseId, user);
     const updatedGABusinessProcessData = await updatedBusinessProcess.json();
-    assert.equal(updatedGABusinessProcessData.ccdState, 'APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION');
+    assert.equal(updatedGABusinessProcessData.ccdState, 'PROCEEDS_IN_HERITAGE');
     await addUserCaseMapping(gaCaseId, user);
   },
 

--- a/e2e/tests/api_unspec_claim_tests/api_1v1_directions_order_test.js
+++ b/e2e/tests/api_unspec_claim_tests/api_1v1_directions_order_test.js
@@ -38,7 +38,7 @@ Scenario('Judge makes decision 1V1 - VARY-JUDGEMENT - DIRECTIONS ORDER - Respond
   await api.assertDocumentVisibilityToUser(config.applicantSolicitorUser, 'Claimant', civilCaseReference, gaCaseReference, doc);
 });
 
-Scenario('Judge makes decision 1V1 - VARY-JUDGEMENT  as DEFENDANT - DIRECTIONS ORDER - Respondent upload Directions Document', async ({api}) => {
+Scenario('Judge makes decision 1V1 - VARY-JUDGEMENT  as DEFENDANT - PROCEEDS IN HERITAGE', async ({api}) => {
   civilCaseReference = await api.createUnspecifiedClaim(config.applicantSolicitorUser, mpScenario, 'Company', '11000');
   await api.amendClaimDocuments(config.applicantSolicitorUser);
   await api.notifyClaim(config.applicantSolicitorUser, mpScenario, civilCaseReference);
@@ -53,20 +53,6 @@ Scenario('Judge makes decision 1V1 - VARY-JUDGEMENT  as DEFENDANT - DIRECTIONS O
   console.log('*** Start response to GA Case Reference: ' + gaCaseReference + ' ***');
   await api.respondentDebtorResponse(config.applicantSolicitorUser, gaCaseReference, false);
   console.log('*** End Response to GA Case Reference: ' + gaCaseReference + ' ***');
-
-  console.log('*** Start Judge Directions Order on GA Case Reference: ' + gaCaseReference + ' ***');
-  if (['preview', 'demo', 'aat'].includes(config.runningEnv)) {
-    await api.judgeMakesDecisionDirectionsOrder(config.judgeUser2WithRegionId2, gaCaseReference);
-  } else {
-    await api.judgeMakesDecisionDirectionsOrder(config.judgeLocalUser, gaCaseReference);
-  }
-  console.log('*** End Judge Directions Order GA Case Reference: ' + gaCaseReference + ' ***');
-
-  console.log('*** Start Respondent respond to Judge Directions on GA Case Reference: ' + gaCaseReference + ' ***');
-  await api.respondentResponseToJudgeDirections(config.applicantSolicitorUser, gaCaseReference);
-  console.log('*** End Respondent respond to Judge Directions GA Case Reference: ' + gaCaseReference + ' ***');
-  let doc = 'gaAddl';
-  await api.assertDocumentVisibilityToUser(config.applicantSolicitorUser, 'RespondentSol', civilCaseReference, gaCaseReference, doc);
 });
 AfterSuite(async ({api}) => {
   await api.cleanUp();


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/CIV-16638
https://tools.hmcts.net/jira/browse/CIV-16640

Change description
The judgment journey that succeeds a decision made on an application to vary judgment has been descoped from judgments online, and therefore, there is no journey available to keep this application type journey online. The scope of this ticket is to trigger the work allocation to take the case offline in this scenario. This covers defendant LiP and defendant LRs making applications to vary judgment - the WA should be triggered at the point the claimant responds (either LR or LiP).

The decisions has been made to take the main claim and application (plus any other applications on the case) offline in this instance.

The scope of this ticket is to enable the following:

Vary judgment is submitted by defendant (LR or LiP)
The WA to the judge to make a decision needs to be suppressed
WA sent to caseworker to take main case offline
Work allocation task needs to contain meaningful text to accurately display description - static text
Notifications are handled in [CIV-16640](https://tools.hmcts.net/jira/browse/CIV-16640)

Scope applies to both with consent and with notice applications - and includes LR v LR; LiP v LiP; LR v LiP and LiP v LR.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```

















